### PR TITLE
feature: make module constants public to allow their usage in user code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- [x] feature: make module constants public to allow their usage in user code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imohash"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["hiql <qiu_lin@163.com>"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ for:
 The original project created by
 [Jim Kalafut](https://github.com/kalafut), check out https://github.com/kalafut/imohash
 
-License: MIT
+## [Changelog](CHANGELOG.md)
+## [License (MIT)](LICENSE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl Hasher {
         reader.rewind()?;
         if self.sample_size < 1
             || size < self.sample_threshold as u64
-            || size < (2 * self.sample_size - 1) as u64
+            || size < (4 * self.sample_size) as u64
         {
             reader.read_to_end(&mut buffer)?;
         } else {
@@ -264,10 +264,10 @@ mod tests {
             (16384, 131073, 131072, "808008282d3f3b53e1fd132cc51fcc1d"),
             (16384, 131072, 500000, "a0c21e44a0ba3bddee802a9d1c5332ca"),
             (50, 131072, 300000, "e0a712edd8815c606344aed13c44adcf"),
-            (0, 100, 1000, "e80753211a57ee0de67c756e98e00496"),
-            (50, 9999, 1000, "e80753211a57ee0de67c756e98e00496"),
-            (501, 20, 1000, "e80753211a57ee0de67c756e98e00496"),
-            (501, 20, 1001, "e9079899cffb46f60c8645a01f12f9c9"),
+            (0, 100, 999, "e7078bfc9bdf7d7706adbd21002bb752"),
+            (50, 9999, 999, "e7078bfc9bdf7d7706adbd21002bb752"),
+            (250, 20, 999, "e7078bfc9bdf7d7706adbd21002bb752"),
+            (250, 20, 1000, "e807ae87d3dafb5eb6518a5a256297e9"),
         ];
 
         for test in tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,11 @@ use std::fs::File;
 use std::io::{BufReader, Cursor, Read, Result, Seek, SeekFrom};
 use std::path::Path;
 
-const SAMPLE_THRESHOLD: u32 = 128 * 1024;
-const SAMPLE_SIZE: u32 = 16 * 1024;
+/// Default sample threshold value
+pub const SAMPLE_THRESHOLD: u32 = 128 * 1024;
+
+/// Default sample size value
+pub const SAMPLE_SIZE: u32 = 16 * 1024;
 
 /// A hasher which holds the custom sample parameters, and provides the APIs
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
**purpose:** constants usage are required for creating `Hasher` instance in case, when at least one parameter (either `SAMPLE_THRESHOLD` or `SAMPLE_SIZE`) is not fulfilled.

for example: https://github.com/unsektor/py-imohash/blob/master/src/lib.rs#L69-L70